### PR TITLE
Add support for .flac and .mp3 files

### DIFF
--- a/MiniAudio/Code/Source/Tools/MiniAudioEditorSystemComponent.cpp
+++ b/MiniAudio/Code/Source/Tools/MiniAudioEditorSystemComponent.cpp
@@ -72,6 +72,10 @@ namespace MiniAudio
         materialAssetBuilderDescriptor.m_version = 2; // bump this to rebuild all sound files
         materialAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.wav",
             AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
+        materialAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.flac",
+            AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
+        materialAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.mp3",
+            AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
         materialAssetBuilderDescriptor.m_busId = azrtti_typeid<SoundAssetBuilder>();
         materialAssetBuilderDescriptor.m_createJobFunction = [this](const AssetBuilderSDK::CreateJobsRequest& request,
             AssetBuilderSDK::CreateJobsResponse& response)


### PR DESCRIPTION
From my testing, so long as files that use the various extensions have different filenames, then this works just fine.

If the files have the same name (not considering the difference in their extensions), then O3DE's asset processor could complain. The error says something along the lines of "A different source file \<filename\> is outputting the product".

Even with this small quirk, it's very useful to accept .flac and .mp3 files as well.