### PR TITLE
Removing Duplicate Serialize Context Class

### DIFF
--- a/MiniAudio/Code/Source/Tools/MiniAudioEditorSystemComponent.cpp
+++ b/MiniAudio/Code/Source/Tools/MiniAudioEditorSystemComponent.cpp
@@ -19,12 +19,6 @@ namespace MiniAudio
     {
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serializeContext->Class<MiniAudioEditorSystemComponent, MiniAudioSystemComponent>()
-                ->Version(0);
-        }
-
-        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
-        {
             serializeContext->Class<MiniAudioEditorSystemComponent, AZ::Component>()
                 ->Version(1)
                 ->Attribute(AZ::Edit::Attributes::SystemComponentTags, AZStd::vector<AZ::Crc32>({ AZ_CRC_CE("AssetBuilder") }))


### PR DESCRIPTION
Fixing assert on startup caused by from defining the MiniAudio serialize context twice.